### PR TITLE
Fix missing close on t_gender

### DIFF
--- a/templates/sociodemography.md
+++ b/templates/sociodemography.md
@@ -34,7 +34,7 @@ Questions in this section:
 {{t_gender}}
 
 {{{f_gender}}}
-{{#t_gender}}
+{{/t_gender}}
 
 {{#t_ethnicity}}
 ### Ethnicity


### PR DESCRIPTION
Regenerating the survey causes the following:

[9/14] survey.sociodemography FAIL
Traceback (most recent call last):
  File "/home/vagrant/international-survey-2018/lib/run.py", line 40, in run
    importlib.import_module(m).run()
  File "/home/vagrant/international-survey-2018/lib/report.py", line 79, in func
    (Path(REPORT_PATH) / (filename)).write_text(chevron.render(fp, report))
  File "/home/vagrant/international-survey-2018/venv/lib/python3.8/site-packages/chevron/renderer.py", line 308, in render
    for tag in tokens:
  File "/home/vagrant/international-survey-2018/venv/lib/python3.8/site-packages/chevron/tokenizer.py", line 220, in tokenize
    raise ChevronError('Trying to close tag "{0}"\n'
chevron.tokenizer.ChevronError: Trying to close tag "countries"

This PR fixes a mislabelled `{{#t_gender}}` which should be `{{/t_gender}}` in `templates/sociodemography.md`.